### PR TITLE
Pool.Queue.cleanup(): use addAll instead of add called in a loop

### DIFF
--- a/src/io/aleph/dirigiste/Pool.java
+++ b/src/io/aleph/dirigiste/Pool.java
@@ -141,8 +141,8 @@ public class Pool<K,V> implements IPool<K,V> {
 
             int numObjects = objects.get();
 
-            for (V o : live) {
-                _puts.add(o);
+            if (! live.isEmpty()) {
+                _puts.addAll(live);
             }
 
             _lock.unlock();


### PR DESCRIPTION
Here is a simple optimization suggested by my IDE. Instead of calling `add()` in a loop we can rely on the `addAll()` method that adds all elements at once in bulk. Supposedly more efficient when the `live` list has more than one element. 
