### PR TITLE
Make `_isShutdown` volatile

### DIFF
--- a/src/io/aleph/dirigiste/Pool.java
+++ b/src/io/aleph/dirigiste/Pool.java
@@ -10,7 +10,7 @@ public class Pool<K,V> implements IPool<K,V> {
     // pooled object queue
     class Queue {
 
-        private boolean _isShutdown = false;
+        private volatile boolean _isShutdown = false;
 
         private final Deque<AcquireCallback<V>> _takes;
         private final Deque<V> _puts = new LinkedBlockingDeque();
@@ -206,7 +206,7 @@ public class Pool<K,V> implements IPool<K,V> {
     private final Controller<K> _controller;
     private final double _rateMultiplier;
 
-    private boolean _isShutdown = false;
+    private volatile boolean _isShutdown = false;
 
     private final AtomicInteger _numObjects = new AtomicInteger(0);
     private final ReentrantLock _lock = new ReentrantLock();


### PR DESCRIPTION
It's read/written by different threads (particularly, it's read by the daemon thread defined in the Pool constructor).

Because access to the variable isn't guarded by a synchronized block or the `volatile` modifier, there isn't a visibility guarantee across threads.

This would be a reasonable explanation for a thread leak I'm experiencing.