### PR TITLE
Executor: awaitTermination should return false if latch timed out

### DIFF
--- a/src/io/aleph/dirigiste/Executor.java
+++ b/src/io/aleph/dirigiste/Executor.java
@@ -238,7 +238,9 @@ public class Executor extends AbstractExecutorService {
             if (remaining < 0) {
                 return false;
             }
-            w._latch.await(remaining, TimeUnit.MILLISECONDS);
+            if(!w._latch.await(remaining, TimeUnit.MILLISECONDS)) {
+                return false;
+            };
         }
 
         return true;

--- a/test/java/io/aleph/dirigiste/ExecutorTest.java
+++ b/test/java/io/aleph/dirigiste/ExecutorTest.java
@@ -1,0 +1,27 @@
+package io.aleph.dirigiste;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+
+public class ExecutorTest {
+    @Test
+    public void testAwaitTerminationShouldReturnFalse() throws InterruptedException {
+        Executor executor = Executors.fixedExecutor(1);
+        executor.executeWithoutRejection(() -> {});
+        executor.shutdown();
+        boolean result = executor.awaitTermination(500, TimeUnit.MICROSECONDS);
+        assertFalse(result);
+    }
+
+    @Test
+    public void testAwaitTerminationShouldReturnTrue() throws InterruptedException {
+        Executor executor = Executors.fixedExecutor(1);
+        executor.executeWithoutRejection(() -> {});
+        executor.shutdown();
+        boolean result = executor.awaitTermination(1200, TimeUnit.MICROSECONDS);
+        assertTrue(result);
+    }
+}


### PR DESCRIPTION
## Description

`awaitTermination` should return false if latch timed out

Fixes #29 