### PR TITLE
Protect workers from shutting down from racy interrupts

### DIFF
--- a/src/io/aleph/dirigiste/Executor.java
+++ b/src/io/aleph/dirigiste/Executor.java
@@ -44,11 +44,10 @@ public class Executor extends AbstractExecutorService {
             Runnable runnable =
                 new Runnable() {
                     public void run() {
-                        try {
+                        _birth = System.nanoTime();
 
-                            _birth = System.nanoTime();
-
-                            while (!_isShutdown) {
+                        while (!_isShutdown) {
+                            try {
                                 Runnable r = (Runnable) _queue.poll(1000, TimeUnit.MILLISECONDS);
 
                                 if (r != null) {
@@ -74,9 +73,15 @@ public class Executor extends AbstractExecutorService {
                                         }
                                     }
                                 }
+                            } catch (InterruptedException e) {
+                                // The worker thread may occasionally catch a
+                                // stray interrupt targetted at the task that
+                                // raced through. We don't want such races to
+                                // kill the worker thread, so ignore and
+                                // continue with the loop. If the interrupt is
+                                // meant for the worker thread, then _isShutdown
+                                // woud be armed as well.
                             }
-                        } catch (InterruptedException e) {
-
                         }
                         _workers.remove(Worker.this);
                         _latch.countDown();


### PR DESCRIPTION
In the current Executor implementation, whenever a worker thread catches InterruptedException, it presumes that the interrupt is meant for him and ceases to run the worker loop. But because the interrupts are racy, an interrupt meant for a task may arrive after the task has already finished. This will cause the Worker thread to die for no reason. This is not a big deal if the executor is dynamically sized, but in case of statically configured executors, the executor will eventually run out of workers.

The patch includes a test that reproduces the behavior. I can reliably observe the test failing without the patch.

The patch moves the catch handler inside the loop, so after catching a racy interrupt the worker will go on with the loop.